### PR TITLE
Close file stream

### DIFF
--- a/src/bgc_part_0725_io.md
+++ b/src/bgc_part_0725_io.md
@@ -486,6 +486,8 @@ int main(void)
 
     while (fread(&c, sizeof(char), 1, fp) > 0)
         printf("%d\n", c);
+
+    fclose(fp);
 }
 ```
 [i[`fread()` function]>]


### PR DESCRIPTION
Missed closing the file stream in the `fread()` code snippet under the Binary File I/O section (ch. 9.6).